### PR TITLE
Removed unneeded creature or player target

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SavraQueenOfTheGolgari.java
+++ b/Mage.Sets/src/mage/cards/s/SavraQueenOfTheGolgari.java
@@ -87,7 +87,6 @@ class SavraSacrificeBlackCreatureAbility extends TriggeredAbilityImpl {
 
     public SavraSacrificeBlackCreatureAbility() {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new SavraSacrificeEffect(), new PayLifeCost(2)));
-        this.addTarget(new TargetCreatureOrPlayer());
         this.setLeavesTheBattlefieldTrigger(true);
     }
 


### PR DESCRIPTION
Removed unneeded creature or player target when triggering Savra's first ability